### PR TITLE
Default to V2 Contracts and use HTTP instead of GRPC

### DIFF
--- a/basic-app/.env.example
+++ b/basic-app/.env.example
@@ -1,18 +1,12 @@
 # Learn how to get your app's client ID, client secret and API key from https://docs.niftory.com/home/v/api/core-concepts/authentication/using-your-api-key
-NEXT_PUBLIC_API_KEY="eoKwSh8OSxM3SL3u51dWdA3gXMnKvr5tln1daWuPp9c="
-NEXT_PUBLIC_CLIENT_ID="NiftorySampleApp"
+NEXT_PUBLIC_API_KEY="beYyMaLIucJIt6CPFCAni2L0mYQ7nXnllNLYKVAgcTM="
+NEXT_PUBLIC_CLIENT_ID="clb5tge0u00190hlblveh331l"
 
 # Never share the client secret with anyone, and don't commit the .env file containing the secret. Consider using something like Vercel to manage your app deployments and environment variables.
-
 # For more information see: https://docs.niftory.com/home/v/api/core-concepts/authentication/configuring-your-app#client-secret
 CLIENT_SECRET="super_secret_client_secret_that_is_unique_to_your_app_DO_NOT_SHARE_OR_COMMIT"
 
-# Possible Contract Version values are V1 and V2.
-# If using this with the current NiftorySampleApp Org in the Niftory Staging Environment, please update this to V1.
-NEXT_PUBLIC_CONTRACT_VERSION="V2"
-
 # See https://docs.niftory.com/home/v/api/reference/graphql-and-auth-endpoints
-
 # testnet endpoints are _.staging.niftory.com, and mainnet ones are the same but without 'staging' (i.e. _.niftory.com).
 NIFTORY_AUTH_ISSUER="https://auth.staging.niftory.com"
 NEXT_PUBLIC_API_PATH="https://graphql.api.staging.niftory.com"
@@ -24,29 +18,29 @@ NEXTAUTH_URL="http://localhost:3000"
 
 # As above, this is specific to next-auth, used to encrypt cookies. https://next-auth.js.org/configuration/options#secret
 # You can generate a unique ID by running `openssl rand -base64 32`
-NEXTAUTH_SECRET="OBDgu7htVoon39p08A4mzGecSmiVga8InIuJ6abF0/g="
+NEXTAUTH_SECRET="myauthsecret"
 
-# For the Flow blockchain, testnet access node is "https://access-testnet.onflow.org", and mainnet is "https://access.onflow.org"
-
+# For the Flow blockchain, testnet access node is "https://rest-testnet.onflow.org", and mainnet is "https://rest-mainnet.onflow.org"
 # https://docs.onflow.org/faq/developers/#using-the-sdks
+NEXT_PUBLIC_FLOW_ACCESS_API="https://rest-testnet.onflow.org"
 
-NEXT_PUBLIC_FLOW_ACCESS_API="https://access-testnet.onflow.org"
-
-# The sample app uses Blocto for wallets. You can use a different provider.
-
+# The sample app uses Dapper for wallets.
 NEXT_PUBLIC_WALLET_API="https://flow-wallet-testnet.blocto.app/authn/"
 
-# The global NFT Contract address. For the Flow blockchain, mainnet contract for NonFungibleToken is 0x1d7e57aa55817448, and testnet is 0x631e88ae7f1d7c20
+# The global NFT Contract address. This is also where MetadataViews are stored on chain.
+# Testnet: 0x631e88ae7f1d7c20
+# Mainnet: 0x1d7e57aa55817448
 # See https://docs.onflow.org/core-contracts/non-fungible-token/
+# See https://github.com/onflow/flow-nft/
 NEXT_PUBLIC_NFT_ADDRESS="0x631e88ae7f1d7c20"
 
-# The global NFT Metadata Views Contract address. For the Flow blockchain, mainnet contract for MetadataViews is 0x1d7e57aa55817448, and testnet is 0x631e88ae7f1d7c20
-# See https://github.com/onflow/flow-nft/
-# This parameter is required when using a Niftory V2 Contract
-NEXT_PUBLIC_METADATA_VIEWS_ADDRESS="0x631e88ae7f1d7c20"
-
-# The below 2 parameters are required when using a Niftory V2 Contract
+# The following values are required for Niftory
+# Testnet - Niftory: 0x04f74f0252479aed, Registry: 0x6085ae87e78e1433
+# Mainnet - Niftory: 0x7ec1f607f0872a9e, Registry: 0x32d62d5c43ad1038
 NEXT_PUBLIC_NIFTORY_ADDRESS="0x04f74f0252479aed"
 NEXT_PUBLIC_REGISTRY_ADDRESS="0x6085ae87e78e1433"
+
+# This parameter is the account that funds will be sent to when NFTs are purchased. Use the account address for your Dapper organization.
+NEXT_PUBLIC_MERCHANT_ACCOUNT_ADDRESS="0x96e4f6c4fcb01441"
 
 # For more information, head over to the Niftory API docs: https://docs.niftory.com/home/v/api/

--- a/basic-app/hooks/useContractCadence.tsx
+++ b/basic-app/hooks/useContractCadence.tsx
@@ -12,24 +12,12 @@ gql`
 `
 
 const nonFungibleTokenAddress = process.env.NEXT_PUBLIC_NFT_ADDRESS
-const metadataViewsAddress = process.env.NEXT_PUBLIC_METADATA_VIEWS_ADDRESS
+const metadataViewsAddress = process.env.NEXT_PUBLIC_NFT_ADDRESS
 const niftoryAddress = process.env.NEXT_PUBLIC_NIFTORY_ADDRESS
 const registryAddress = process.env.NEXT_PUBLIC_REGISTRY_ADDRESS
 const clientId = process.env.NEXT_PUBLIC_CLIENT_ID
-const contractVersion = process.env.NEXT_PUBLIC_CONTRACT_VERSION
-const IS_ACCOUNT_CONFIGURED__SCRIPT = `
-    import {contractName} from {contractAddress}
-    import NonFungibleToken from ${nonFungibleTokenAddress}
 
-    pub fun main(account: Address): Bool {
-
-        let acct = getAccount(account)
-
-        return acct.getCapability<&{{contractName}.{contractName}CollectionPublic}>({contractName}.CollectionPublicPath).check()
-
-    }`
-
-const IS_ACCOUNT_CONFIGURED_V2__SCRIPT = `
+const IS_ACCOUNT_CONFIGURED_SCRIPT = `
     import NonFungibleToken from ${nonFungibleTokenAddress}
     import MetadataViews from ${metadataViewsAddress}
     import NiftoryNonFungibleToken from ${niftoryAddress}
@@ -51,41 +39,8 @@ const IS_ACCOUNT_CONFIGURED_V2__SCRIPT = `
 
     }`
 
-const CONFIGURE_ACCOUNT__TRANSACTION = `
-    import {contractName} from {contractAddress}
-    import NonFungibleToken from ${nonFungibleTokenAddress}
-    import MetadataViews from ${nonFungibleTokenAddress}
 
-    // This transaction sets up an account to collect Collectibles
-    // by storing an empty collectible collection and creating
-    // a public capability for it
-
-    transaction {
-
-        prepare(acct: AuthAccount) {
-
-            // First, check to see if a collectible collection already exists
-            if acct.borrow<&{contractName}.Collection>(from: {contractName}.CollectionStoragePath) == nil {
-
-                // create a new {contractName} Collection
-                let collection <- {contractName}.createEmptyCollection() as! @{contractName}.Collection
-
-                // Put the new Collection in storage
-                acct.save(<-collection, to: {contractName}.CollectionStoragePath)
-            }
-
-            // create a public capability for the collection
-            acct.unlink({contractName}.CollectionPublicPath)
-            acct.link<&{
-                {contractName}.{contractName}CollectionPublic,
-                NonFungibleToken.Receiver,
-                NonFungibleToken.CollectionPublic,
-                MetadataViews.ResolverCollection
-            }>({contractName}.CollectionPublicPath, target: {contractName}.CollectionStoragePath)
-        }
-    }`
-
-const CONFIGURE_ACCOUNT_V2__TRANSACTION = `
+const CONFIGURE_ACCOUNT_TRANSACTION = `
     import NonFungibleToken from ${nonFungibleTokenAddress}
     import MetadataViews from ${metadataViewsAddress}
     import NiftoryNonFungibleToken from ${niftoryAddress}
@@ -131,13 +86,13 @@ export function useContractCadence() {
     const { name, address } = data?.contract
 
     isAccountConfigured_script = prepareCadence(
-      contractVersion === "V2" ? IS_ACCOUNT_CONFIGURED_V2__SCRIPT : IS_ACCOUNT_CONFIGURED__SCRIPT,
+      IS_ACCOUNT_CONFIGURED_SCRIPT,
       name,
       address
     )
 
     configureAccount_transaction = prepareCadence(
-      contractVersion === "V2" ? CONFIGURE_ACCOUNT_V2__TRANSACTION : CONFIGURE_ACCOUNT__TRANSACTION,
+      CONFIGURE_ACCOUNT_TRANSACTION,
       name,
       address
     )

--- a/basic-app/hooks/useFlowUser.tsx
+++ b/basic-app/hooks/useFlowUser.tsx
@@ -1,5 +1,4 @@
 import * as fcl from "@onflow/fcl"
-import { send as grpcSend } from "@onflow/transport-grpc"
 import { useMemo, useState } from "react"
 
 export function useFlowUser() {
@@ -8,7 +7,6 @@ export function useFlowUser() {
   useMemo(() => {
     fcl
       .config()
-      .put("sdk.transport", grpcSend)
       .put("accessNode.api", process.env.NEXT_PUBLIC_FLOW_ACCESS_API) // connect to Flow
       .put("discovery.wallet", process.env.NEXT_PUBLIC_WALLET_API) // use Blocto wallet
 


### PR DESCRIPTION
Details in Title. The app now uses the V2 contract by default and the Flow FCL transport is HTTP instead of GRPC